### PR TITLE
Add: Omit E-mail confirmation

### DIFF
--- a/Server/Areas/Identity/Pages/Account/ConfirmEmail.cshtml
+++ b/Server/Areas/Identity/Pages/Account/ConfirmEmail.cshtml
@@ -1,0 +1,11 @@
+﻿@page
+@model ConfirmEmailModel
+@{
+    ViewData["Title"] = "Confirm email";
+}
+
+<h1>@ViewData["Title"]</h1>
+
+<p>
+    Eメールによってユーザーを確認しました。<a href="/">ロビー</a>に移動してください。
+</p>

--- a/Server/Areas/Identity/Pages/Account/ConfirmEmail.cshtml.cs
+++ b/Server/Areas/Identity/Pages/Account/ConfirmEmail.cshtml.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using blazorTest.Server.Models;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.WebUtilities;
+
+namespace blazorTest.Server.Areas.Identity.Pages.Account
+{
+    [AllowAnonymous]
+    public class ConfirmEmailModel : PageModel
+    {
+        private readonly UserManager<ApplicationUser> _userManager;
+
+        public ConfirmEmailModel(UserManager<ApplicationUser> userManager)
+        {
+            _userManager = userManager;
+        }
+
+        [TempData]
+        public string StatusMessage { get; set; }
+
+        public async Task<IActionResult> OnGetAsync(string userId, string code)
+        {
+            if (userId == null || code == null)
+            {
+                return RedirectToPage("/Index");
+            }
+
+            var user = await _userManager.FindByIdAsync(userId);
+            if (user == null)
+            {
+                return NotFound($"Unable to load user with ID '{userId}'.");
+            }
+
+            code = Encoding.UTF8.GetString(WebEncoders.Base64UrlDecode(code));
+            var result = await _userManager.ConfirmEmailAsync(user, code);
+            StatusMessage = result.Succeeded ? "Thank you for confirming your email." : "Error confirming your email.";
+            return Page();
+        }
+    }
+}

--- a/Server/Areas/Identity/Pages/Account/RegisterConfirmation.cshtml
+++ b/Server/Areas/Identity/Pages/Account/RegisterConfirmation.cshtml
@@ -1,0 +1,21 @@
+﻿@page
+@model RegisterConfirmationModel
+@{
+    ViewData["Title"] = "Register confirmation";
+}
+
+<h1>@ViewData["Title"]</h1>
+@{
+    if (@Model.DisplayConfirmAccountLink)
+    {
+        <p>
+            Eメールによるユーザー確認は実装途中です。この<a id="confirm-link" href="@Model.EmailConfirmationUrl">リンクをクリックして</a>確認処理を省略してロビーに進むことができます。
+        </p>
+    }
+    else
+    {
+        <p>
+            Please check your email to confirm your account.
+        </p>
+    }
+}

--- a/Server/Areas/Identity/Pages/Account/RegisterConfirmation.cshtml.cs
+++ b/Server/Areas/Identity/Pages/Account/RegisterConfirmation.cshtml.cs
@@ -1,0 +1,62 @@
+﻿using blazorTest.Server.Models;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Identity.UI.Services;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.WebUtilities;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace blazorTest.Server.Areas.Identity.Pages.Account
+{
+    [AllowAnonymous]
+    public class RegisterConfirmationModel : PageModel
+    {
+        private readonly UserManager<ApplicationUser> _userManager;
+        private readonly IEmailSender _sender;
+
+        public RegisterConfirmationModel(UserManager<ApplicationUser> userManager, IEmailSender sender)
+        {
+            _userManager = userManager;
+            _sender = sender;
+        }
+
+        public string Email { get; set; }
+
+        public bool DisplayConfirmAccountLink { get; set; }
+
+        public string EmailConfirmationUrl { get; set; }
+
+        public async Task<IActionResult> OnGetAsync(string email, string returnUrl = null)
+        {
+            if (email == null)
+            {
+                return RedirectToPage("/Index");
+            }
+
+            var user = await _userManager.FindByEmailAsync(email);
+            if (user == null)
+            {
+                return NotFound($"Unable to load user with email '{email}'.");
+            }
+
+            Email = email;
+            // Once you add a real email sender, you should remove this code that lets you confirm the account
+            DisplayConfirmAccountLink = true;
+            if (DisplayConfirmAccountLink)
+            {
+                var userId = await _userManager.GetUserIdAsync(user);
+                var code = await _userManager.GenerateEmailConfirmationTokenAsync(user);
+                code = WebEncoders.Base64UrlEncode(Encoding.UTF8.GetBytes(code));
+                EmailConfirmationUrl = Url.Page(
+                    "/Account/ConfirmEmail",
+                    pageHandler: null,
+                    values: new { area = "Identity", userId = userId, code = code, returnUrl = returnUrl },
+                    protocol: Request.Scheme);
+            }
+
+            return Page();
+        }
+    }
+}


### PR DESCRIPTION
Eメール関連の手続きを省略するところを足してあります。
やっていることは、E-mailに送る予定だったURLをサイト側に表示することと、そこからロビー相当の画面(Index.razor)へのリンクを貼ってやることだけです。

＃IEmailSender でメールを経由したユーザー確認の実装は年初にやりましょう。今日やってみたら簡単でしたよ。
＃画面は少しお待ちを。ちょっとよくわからないバグが出ていて対応中。