### PR TITLE
IIndexPresenter を削除する

### DIFF
--- a/Client/Pages/Chat.razor
+++ b/Client/Pages/Chat.razor
@@ -12,6 +12,8 @@
 @inject IHttpClientFactory IHttpClientFactory
 @inject AuthenticationStateProvider AuthenticationStateProvider
 @inject HubUtility HubUtility
+@inject ChatViewModel ViewModel
+
 @attribute [Authorize]
 @implements IDisposable
 @implements Chat.IPresenter
@@ -122,8 +124,6 @@
     {
         Task<UserInfo> GetUserAsync();
 
-        IHttpClientFactory GetHttpClientFactory();
-
         NavigationManager GetNavigationManager();
 
         HubConnection GetHabConnection();
@@ -144,8 +144,6 @@
         return new() { Id = user.Identity.Name, Name = user.Claims.FirstOrDefault(each => each.Type == "HandleName")?.Value };
     }
 
-    public IHttpClientFactory GetHttpClientFactory() => IHttpClientFactory;
-
     public NavigationManager GetNavigationManager() => NavigationManager;
 
     public HubConnection GetHabConnection() => _hubConnection;
@@ -164,8 +162,6 @@
 
     private Guid _roomId;
 
-    private ChatViewModel ViewModel { get; set; } = new(null, Guid.Empty);
-
     [Parameter]
     public Guid RoomId
     {
@@ -177,8 +173,6 @@
 
             _roomId = value;
             _hubConnection = HubUtility.CreateHubConnection();
-            ViewModel = new ChatViewModel(this as IPresenter, _roomId);
-            _fragment = null;
         }
     }
 
@@ -201,15 +195,17 @@
 
     public bool IsConnected => _hubConnection.State == HubConnectionState.Connected;
 
-    protected override void OnInitialized()
+    protected override async Task OnInitializedAsync()
     {
-        if (ViewModel is null)
-            ViewModel = new ChatViewModel(this as IPresenter, _roomId);
+        await ViewModel.InitializeAsync(this, _roomId);
     }
 
     protected override async Task OnParametersSetAsync()
     {
         await base.OnParametersSetAsync();
+
+        _fragment = null;
+        await ViewModel.InitializeAsync(this as IPresenter, _roomId);
 
         if (string.IsNullOrEmpty(_fragment))
             await ViewModel.RefreshAsync();

--- a/Client/Pages/Index.razor
+++ b/Client/Pages/Index.razor
@@ -24,7 +24,10 @@
     <AuthorizeView>
         <Authorized>
             <div class="margin8">
-                @{ userEmail = context.User.Identity.Name;}
+                @{
+                    userEmail = context.User.Identity.Name;
+                    indexViewModel.IsLoggedIn = true;
+                }
                 @if (indexViewModel?.Rooms is null)
                 {
                     <div>ルームを読み取り中…</div>

--- a/Client/Program.cs
+++ b/Client/Program.cs
@@ -1,5 +1,6 @@
 using ChatApp.Client.Models;
 using ChatApp.Client.Services;
+using ChatApp.Client.ViewModel;
 using Microsoft.AspNetCore.Components.WebAssembly.Authentication;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using Microsoft.Extensions.DependencyInjection;
@@ -27,6 +28,10 @@ namespace ChatApp.Client
             builder.Services.AddApiAuthorization();
 
             builder.Services.AddSingleton<IRoomManager, RoomManager>();
+
+            builder.Services.AddSingleton<IndexModel>();
+            builder.Services.AddTransient<IndexViewModel>();
+            builder.Services.AddTransient<ChatViewModel>();
 
             await builder.Build().RunAsync();
         }

--- a/Client/Shared/MainLayout.razor
+++ b/Client/Shared/MainLayout.razor
@@ -3,7 +3,6 @@
 @inject AuthenticationStateProvider AuthenticationStateProvider
 @inject IHttpClientFactory HttpClientFactory
 @inject IndexViewModel ViewModel
-@implements MainLayout.IIndexPresenter
 
 <style type="text/css">
     .app-layout {
@@ -53,16 +52,9 @@
 </div>
 
 @code {
-
-    public interface IIndexPresenter
-    {
-        void Invalidate();
-    }
-
-    public void Invalidate() => StateHasChanged();
-
     protected override void OnInitialized()
     {
-        ViewModel.Initialize(this);
+        // 通常は WeakReferenceEvent を用いるべきだが、ライフサイクルが同期しているので強い参照を容認する
+        ViewModel.PropertyChanged += (_, _) => StateHasChanged();
     }
 }

--- a/Client/Shared/MainLayout.razor
+++ b/Client/Shared/MainLayout.razor
@@ -1,7 +1,8 @@
 ﻿@using ChatApp.Client.ViewModel;
 @inherits LayoutComponentBase
 @inject AuthenticationStateProvider AuthenticationStateProvider
-@inject IHttpClientFactory IHttpClientFactory
+@inject IHttpClientFactory HttpClientFactory
+@inject IndexViewModel ViewModel
 @implements MainLayout.IIndexPresenter
 
 <style type="text/css">
@@ -37,7 +38,7 @@
 <div class="app-layout">
     <div class="teams"></div>
     <div class="sidebar">
-        <CascadingValue Value="viewModel">
+        <CascadingValue Value="ViewModel">
             <NavMenu />
         </CascadingValue>
     </div>
@@ -45,7 +46,7 @@
         <LoginDisplay />
     </div>
     <div class="body">
-        <CascadingValue Value="viewModel">
+        <CascadingValue Value="ViewModel">
             @Body
         </CascadingValue>
     </div>
@@ -55,24 +56,13 @@
 
     public interface IIndexPresenter
     {
-        Task<string> GetUserIdAsync();
-
-        IHttpClientFactory GetHttpClientFactory();
-
         void Invalidate();
     }
 
-    public async Task<string> GetUserIdAsync()
-        => (await AuthenticationStateProvider.GetAuthenticationStateAsync()).User.Identity.Name;
-
-    public IHttpClientFactory GetHttpClientFactory() => IHttpClientFactory;
-
     public void Invalidate() => StateHasChanged();
 
-    private IndexViewModel viewModel { get; set; }
-
-    protected override void OnInitialized()
+    protected override async Task OnInitializedAsync()
     {
-        viewModel = new((IIndexPresenter)this);
+        await ViewModel.InitializeAsync(this);
     }
 }

--- a/Client/Shared/MainLayout.razor
+++ b/Client/Shared/MainLayout.razor
@@ -61,8 +61,8 @@
 
     public void Invalidate() => StateHasChanged();
 
-    protected override async Task OnInitializedAsync()
+    protected override void OnInitialized()
     {
-        await ViewModel.InitializeAsync(this);
+        ViewModel.Initialize(this);
     }
 }

--- a/Client/ViewModel/ChatViewModel.cs
+++ b/Client/ViewModel/ChatViewModel.cs
@@ -16,8 +16,6 @@ namespace ChatApp.Client.ViewModel
     {
         private ChatModel _model;
 
-        private IndexViewModel _indexViewModel;
-
         private Guid _roomId;
 
         public Guid RoomId
@@ -92,7 +90,6 @@ namespace ChatApp.Client.ViewModel
             _roomId = roomId;
             _presenter = presenter;
             _model = new ChatModel(_httpClientFactory, _presenter.GetHabConnection(), roomId);
-            _indexViewModel = presenter.GetIndexViewModel();
 
             UserList = new(presenter, roomId, _model);
 

--- a/Client/ViewModel/IndexViewModel.cs
+++ b/Client/ViewModel/IndexViewModel.cs
@@ -28,7 +28,7 @@ namespace ChatApp.Client.ViewModel
             {
                 if (ValueChangeProcess(ref _isLoggedIn, value) && value)
                 {
-                    Initialize(_presenter);
+                    InitializeRoomList();
                 }
             }
         }
@@ -41,7 +41,10 @@ namespace ChatApp.Client.ViewModel
         public void Initialize(IIndexPresenter presenter)
         {
             _presenter = presenter;
+        }
 
+        private void InitializeRoomList()
+        {
             // 同期処理内で非同期処理を管理する手法。
             Task initialized = Task.CompletedTask;
 

--- a/Client/ViewModel/IndexViewModel.cs
+++ b/Client/ViewModel/IndexViewModel.cs
@@ -14,15 +14,20 @@ namespace ChatApp.Client.ViewModel
 
         public ContentCollection<RoomModel> Rooms = new();
 
-        private readonly IIndexPresenter _presenter;
+        private IIndexPresenter _presenter;
 
-        public IndexViewModel(IIndexPresenter presenter)
+        public IndexViewModel(IndexModel indexModel)
+        {
+            _model = indexModel;
+        }
+
+        public async Task InitializeAsync(IIndexPresenter presenter)
         {
             if (presenter is null) return;
 
             _presenter = presenter;
-            _model = new IndexModel(_presenter.GetHttpClientFactory());
 
+            await _model.InitializeAsync();
             _model.RoomListChanged += (s, e) => OnRoomChanged(e);
         }
 

--- a/Client/ViewModel/IndexViewModel.cs
+++ b/Client/ViewModel/IndexViewModel.cs
@@ -14,10 +14,7 @@ namespace ChatApp.Client.ViewModel
 
         public ContentCollection<RoomModel> Rooms { get; } = new();
 
-        private IIndexPresenter _presenter;
-
         private bool _isLoggedIn;
-
         /// <summary>
         /// ログイン状態
         /// </summary>
@@ -36,11 +33,6 @@ namespace ChatApp.Client.ViewModel
         public IndexViewModel(IndexModel indexModel)
         {
             _model = indexModel;
-        }
-
-        public void Initialize(IIndexPresenter presenter)
-        {
-            _presenter = presenter;
         }
 
         private void InitializeRoomList()
@@ -82,7 +74,7 @@ namespace ChatApp.Client.ViewModel
                 Rooms.Add(target);
             }
 
-            _presenter.Invalidate();
+            OnPropertyChanged(nameof(Rooms));
         }
 
         public async Task CreateRoomAsync(string roomName, List<string> userEmails)


### PR DESCRIPTION
Invalidate()を無くすためには ViewModelからのイベントを捕まえる必要があります。
強い参照を持ちたくはありませんでしたが、ライフタイムが一致しているので此度は容認しました。
マージを検討してください。